### PR TITLE
Pointcloud message header time conversion fix

### DIFF
--- a/src/MapMakerBase.cc
+++ b/src/MapMakerBase.cc
@@ -48,6 +48,7 @@
 #include <ros/common.h>
 #include <pcl_ros/point_cloud.h>
 #include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
 #include <fstream>
 
 MapMakerBase::MapMakerBase(Map& map, bool bAdvertise)
@@ -370,9 +371,11 @@ void MapMakerBase::PublishMapPoints()
   pointMsg->is_dense = false;
   
 #if ROS_VERSION_MINIMUM(1, 9, 56)   // Hydro or above, uses new PCL library
-  pointMsg->header.stamp = ros::Time::now().toNSec();
+  pcl_conversions::toPCL(ros::Time::now(), pointMsg->header.stamp);
+
 #else
   pointMsg->header.stamp = ros::Time::now();
+
 #endif
   
   for(MapPointPtrList::iterator point_it = mMap.mlpPoints.begin(); point_it != mMap.mlpPoints.end(); ++point_it)
@@ -394,8 +397,10 @@ void MapMakerBase::PublishMapPoints()
      
     pointMsg->points.push_back(pclPoint);
   }
+  ROS_INFO_STREAM("MapMakerBase: publishing.");
   
   mMapPointsPub.publish(pointMsg);
+  ROS_INFO_STREAM("MapMakerBase: done publishing.");
 }
 
 // Publish MKFs as a marker array
@@ -465,6 +470,8 @@ void MapMakerBase::MKFToMarker(MultiKeyFrame& mkf, visualization_msgs::Marker& m
 // Publish the map points, then the MKFs
 void MapMakerBase::PublishMapVisualization()
 {
+  ROS_INFO_STREAM("MapMakerBase: PublishMapVisualization starting.");
+ 	
   ROS_DEBUG(" >>>>>>>>>>>>>>>> PUBLISHING MAP VISUALIZATION <<<<<<<<<<<<<<<<<<<<<<<");
   PublishMapPoints();
   PublishMapMKFs();

--- a/src/MapMakerBase.cc
+++ b/src/MapMakerBase.cc
@@ -372,10 +372,8 @@ void MapMakerBase::PublishMapPoints()
   
 #if ROS_VERSION_MINIMUM(1, 9, 56)   // Hydro or above, uses new PCL library
   pcl_conversions::toPCL(ros::Time::now(), pointMsg->header.stamp);
-
 #else
   pointMsg->header.stamp = ros::Time::now();
-
 #endif
   
   for(MapPointPtrList::iterator point_it = mMap.mlpPoints.begin(); point_it != mMap.mlpPoints.end(); ++point_it)
@@ -397,10 +395,8 @@ void MapMakerBase::PublishMapPoints()
      
     pointMsg->points.push_back(pclPoint);
   }
-  ROS_INFO_STREAM("MapMakerBase: publishing.");
-  
+ 
   mMapPointsPub.publish(pointMsg);
-  ROS_INFO_STREAM("MapMakerBase: done publishing.");
 }
 
 // Publish MKFs as a marker array
@@ -470,8 +466,6 @@ void MapMakerBase::MKFToMarker(MultiKeyFrame& mkf, visualization_msgs::Marker& m
 // Publish the map points, then the MKFs
 void MapMakerBase::PublishMapVisualization()
 {
-  ROS_INFO_STREAM("MapMakerBase: PublishMapVisualization starting.");
- 	
   ROS_DEBUG(" >>>>>>>>>>>>>>>> PUBLISHING MAP VISUALIZATION <<<<<<<<<<<<<<<<<<<<<<<");
   PublishMapPoints();
   PublishMapMKFs();


### PR DESCRIPTION
This fix for the latest pcl on Indigo and Ubuntu 14.04 resolved a crash due to an incorrect conversion from ROS time to PCL time.  PCL has a standard conversion class, used instead.  May apply elsewhere in the code, but resolved the issue for me with this one change to MapMakerBase.cc. 